### PR TITLE
Rename MultiTaskFrom to MultiTaskForm

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,60 @@
+const days=['Lunes','Martes','Miércoles','Jueves','Viernes','Sábado','Domingo'];
+const c=document.getElementById('calendar'), wd=document.getElementById('weekDisplay');
+const monthBtn=document.getElementById('monthBtn'), yearBtn=document.getElementById('yearBtn');
+const monthPop=document.getElementById('monthPopover'), yearPop=document.getElementById('yearPopover');
+const taskMenu=document.getElementById('taskMenu'), catGlobal=document.getElementById('categoryGlobal');
+const multiForm=document.getElementById('multiForm'), multiTitle=document.getElementById('multiTitle'), multiDays=document.getElementById('multiDays'), multiConfirm=document.getElementById('multiConfirm');
+let cm=7, cy=2025, cw=`${cy}_${cm}_1`, sel=null;
+
+function getWeekKey(y,m,d){
+  const dt=new Date(y,m-1,d), w=Math.ceil((dt.getDate()+ (dt.getDay()?dt.getDay()-1:6))/7);
+  return `${y}_${m}_${w}`;
+}
+function updateWeek(){const [y,m,w]=cw.split('_'); wd.textContent=`📆 Semana ${w} de ${['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'][m-1]} ${y}`;}
+function genCols(){c.innerHTML='';days.forEach(d=>{const col=document.createElement('div');col.className='day-column';col.innerHTML=`<div class="day-header">${d}</div><div class="task-list" id="${d}"></div><button class="add-task-btn" data-day="${d}">+ Crear</button>`;c.appendChild(col);new Sortable(document.getElementById(d),{group:'all',animation:150,ghostClass:'dragging',onEnd:()=>sel=null});});updateWeek();}
+function makeTask(cat,txt='Nueva tarea'){
+  const t=document.createElement('div');t.className=`task ${cat}`;t.textContent=txt;
+  t.ondblclick=()=>{t.contentEditable=true;t.focus();}
+  t.onblur=()=>t.contentEditable=false;
+  const btn = document.createElement('button');
+btn.className = 'task-menu-btn';
+btn.innerHTML = `<svg width="18" height="18" viewBox="0 0 24 24" fill="white"><circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg>`;
+
+  btn.onclick=e=>{e.stopPropagation();toggle(taskMenu,btn);taskMenu.task=t;};
+  t.appendChild(btn);
+  t.onclick=e=>{if(e.target!==btn){if(sel)sel.classList.remove('selected');sel=t; t.classList.add('selected');}};
+  return t;
+}
+function genMini(){
+  const mc=document.getElementById('mini-calendar');mc.innerHTML='';['L','M','Mi','J','V','S','D'].forEach(h=>{const hh=document.createElement('div');hh.className='day-header';hh.textContent=h;mc.appendChild(hh);});
+  const di=new Date(cy,cm,0).getDate(), sd=new Date(cy,cm-1,1).getDay(), bl=sd?sd-1:6;
+  for(let i=0;i<bl;i++)mc.appendChild(document.createElement('div'));
+  for(let d=1;d<=di;d++){
+    const dc=document.createElement('div');dc.className='day-cell';dc.textContent=d;
+    const wk=getWeekKey(cy,cm,d);
+    if(wk===cw)dc.classList.add('active');
+    dc.onclick=()=>{cw=getWeekKey(cy,cm,d);loadWeek();genMini();};
+    mc.appendChild(dc);
+  }
+}
+function loadWeek(){genCols();}
+function toggle(p,b){if(!p.classList.contains('hidden'))return p.classList.add('hidden');document.querySelectorAll('.popover').forEach(x=>x.classList.add('hidden'));const r=b.getBoundingClientRect();p.style.top=window.scrollY+r.bottom+4+'px';p.style.left=window.scrollX+r.left+'px';p.classList.remove('hidden');}
+monthBtn.onclick=e=>toggle(monthPop,monthBtn);yearBtn.onclick=e=>toggle(yearPop,yearBtn);
+document.querySelectorAll('#monthPopover button').forEach(b=>b.onclick=e=>{cm=parseInt(b.dataset.month);monthBtn.textContent=b.textContent;genMini();loadWeek();monthPop.classList.add('hidden');});
+document.getElementById('confirmYearBtn').onclick=()=>{cy=parseInt(document.getElementById('yearInput').value);yearBtn.textContent=cy;genMini();loadWeek();yearPop.classList.add('hidden');};
+document.addEventListener('click',e=>{if(!monthPop.contains(e.target)&&e.target!==monthBtn)monthPop.classList.add('hidden');if(!yearPop.contains(e.target)&&e.target!==yearBtn)yearPop.classList.add('hidden');if(!taskMenu.contains(e.target)&&!e.target.classList.contains('task-menu-btn'))taskMenu.classList.add('hidden');if(!multiForm.contains(e.target)&&e.target!==document.getElementById('createMultipleBtn'))multiForm.classList.add('hidden');});
+document.getElementById('duplicateTaskOption').onclick=()=>{const t=taskMenu.task;if(t){const cat=[...t.classList].find(x=>x!=='task');document.getElementById(t.parentElement.id).appendChild(makeTask(cat,t.textContent));}taskMenu.classList.add('hidden');};
+document.getElementById('deleteTaskOption').onclick=()=>{const t=taskMenu.task;if(t)t.remove();taskMenu.classList.add('hidden');};
+c.addEventListener('click',e=>{if(e.target.classList.contains('add-task-btn')){const cat=catGlobal.value;document.getElementById(e.target.dataset.day).appendChild(makeTask(cat));}});
+document.getElementById('createMultipleBtn').onclick=e=>{genForm();toggle(multiForm,e.target);};
+function genForm(){multiTitle.value='';multiDays.innerHTML='';days.forEach((d,i)=>{const cb=document.createElement('div');cb.className='day-checkbox';cb.textContent=d.slice(0,2);cb.dataset.day=d;cb.onclick=()=>cb.classList.toggle('active');multiDays.appendChild(cb);});}
+multiConfirm.onclick=()=>{const title=multiTitle.value||'Nueva tarea';const cat=catGlobal.value;multiDays.querySelectorAll('.active').forEach(cb=>{document.getElementById(cb.dataset.day).appendChild(makeTask(cat,title));});multiForm.classList.add('hidden');};
+document.getElementById('exportPdfBtn').onclick=()=>{
+  const doc=new jsPDF();doc.setFontSize(12);doc.text(`Semana ${cw}`,10,10);let y=20;
+  days.forEach(d=>{doc.setFont(undefined,'bold');doc.text(d,10,y);y+=6;doc.setFont(undefined,'normal');
+    document.getElementById(d).querySelectorAll('.task').forEach(t=>{doc.text(`- ${t.textContent}`,12,y);y+=6;});y+=4;});
+  doc.save(`Semana_${cw}.pdf`);
+};
+document.getElementById('toggleDarkMode').onclick=()=>document.body.classList.toggle('dark-mode');
+
+genCols();genMini();loadWeek();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Calendario Semanal</title>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito&display=swap" rel="stylesheet"/>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.jsx"></script>
+  </body>
+</html>

--- a/packege.json
+++ b/packege.json
@@ -1,0 +1,21 @@
+{
+  "name": "calendario-semanal",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "jspdf": "^2.5.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "sortablejs": "^1.15.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.4.1"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import Sidebar from "./components/Sidebar/Sidebar";
+import Calendar from "./components/Calendar/Calendar";
+import WeekDisplay from "./components/Calendar/WeekDisplay";
+import TaskMenu from "./components/Popovers/TaskMenu";
+import MultiTaskForm from "./components/Popovers/MultiTaskForm";
+import MonthPopover from "./components/Sidebar/MonthPopover";
+import YearPopover from "./components/Sidebar/YearPopover";
+import useCalendar from "./hooks/useCalendar";
+import { days, monthNames } from "./utils/dateUtils";
+import "./styles/style.css";
+import "./styles/darkMode.css";
+
+export default function App() {
+  const calendar = useCalendar();
+
+  return (
+    <div className={`app-container ${calendar.darkMode ? "dark-mode" : ""}`}>
+      <Sidebar {...calendar} monthNames={monthNames()} days={days} />
+      <main>
+        <h1>Mi Calendario Semanal</h1>
+        <WeekDisplay currentWeek={calendar.currentWeek} />
+        <Calendar {...calendar} days={days} />
+      </main>
+
+      {/* Popovers */}
+      <MonthPopover {...calendar} monthNames={monthNames()} />
+      <YearPopover {...calendar} />
+      <TaskMenu {...calendar} />
+      <MultiTaskForm {...calendar} days={days} />
+    </div>
+  );
+}

--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import DayColumn from "./DayColumn";
+
+export default function Calendar({
+  days, tasksByDay, addTask, selectedTask, setSelectedTask, setShowTaskMenu
+}) {
+  return (
+    <div id="calendar">
+      {days.map((day) => (
+        <DayColumn
+          key={day}
+          day={day}
+          tasks={tasksByDay[day] || []}
+          onAddTask={() => addTask(day, "tarea")}
+          onSelectTask={(task, index) => {
+            setSelectedTask({ day, task, index });
+            setShowTaskMenu(true);
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Calendar/DayColumn.jsx
+++ b/src/components/Calendar/DayColumn.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Task from "./Task";
+
+export default function DayColumn({ day, tasks, onAddTask, onSelectTask }) {
+  return (
+    <div className="day-column">
+      <div className="day-header">{day}</div>
+      <div className="task-list">
+        {tasks.map((t, i) => (
+          <Task key={i} task={t} onClick={() => onSelectTask(t, i)} />
+        ))}
+      </div>
+      <button className="add-task-btn" onClick={onAddTask}>+ Crear</button>
+    </div>
+  );
+}

--- a/src/components/Calendar/Task.jsx
+++ b/src/components/Calendar/Task.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function Task({ task, onClick }) {
+  return (
+    <div className={`task ${task.category}`} onClick={onClick}>
+      {task.text}
+    </div>
+  );
+}

--- a/src/components/Calendar/WeekDisplay.jsx
+++ b/src/components/Calendar/WeekDisplay.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { monthNames } from "../../utils/dateUtils";
+
+export default function WeekDisplay({ currentWeek }) {
+  const [y, m, w] = currentWeek.split("_");
+  return (
+    <div className="week-display">
+      📆 Semana {w} de {monthNames()[m - 1]} {y}
+    </div>
+  );
+}

--- a/src/components/Popovers/MultiTaskForm.jsx
+++ b/src/components/Popovers/MultiTaskForm.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+
+export default function MultiTaskForm({ showMultiForm, setShowMultiForm, addTask, days }) {
+  const [title, setTitle] = useState("");
+  const [selectedDays, setSelectedDays] = useState([]);
+
+  const toggleDay = (day) => {
+    setSelectedDays(prev =>
+      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day]
+    );
+  };
+
+  const confirm = () => {
+    selectedDays.forEach(day => addTask(day, "tarea", title || "Nueva tarea"));
+    setShowMultiForm(false);
+  };
+
+  if (!showMultiForm) return null;
+
+  return (
+    <div className="popover">
+      <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Nombre tarea" />
+      <div id="multiDays">
+        {days.map((d) => (
+          <div
+            key={d}
+            className={`day-checkbox ${selectedDays.includes(d) ? "active" : ""}`}
+            onClick={() => toggleDay(d)}
+          >
+            {d.slice(0, 2)}
+          </div>
+        ))}
+      </div>
+      <button onClick={confirm}>Aceptar</button>
+    </div>
+  );
+}

--- a/src/components/Popovers/PopoverWrapper.jsx
+++ b/src/components/Popovers/PopoverWrapper.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export default function PopoverWrapper({ children, visible, onClose, className = "" }) {
+  if (!visible) return null;
+
+  return (
+    <div
+      className={`popover ${className}`}
+      onClick={(e) => e.stopPropagation()} // evita cerrar al hacer click dentro
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/Popovers/TaskMenu.jsx
+++ b/src/components/Popovers/TaskMenu.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function TaskMenu({ showTaskMenu, duplicateTask, deleteTask }) {
+  if (!showTaskMenu) return null;
+  return (
+    <div className="popover">
+      <button onClick={duplicateTask}>Duplicar</button>
+      <button onClick={deleteTask}>Eliminar</button>
+    </div>
+  );
+}

--- a/src/components/Sidebar/CategorySelector.jsx
+++ b/src/components/Sidebar/CategorySelector.jsx
@@ -1,0 +1,14 @@
+import React, { useState } from "react";
+
+export default function CategorySelector() {
+  const [category, setCategory] = useState("tarea");
+
+  return (
+    <select value={category} onChange={(e) => setCategory(e.target.value)}>
+      <option value="tarea">📝 Tarea</option>
+      <option value="trabajo">💼 Trabajo</option>
+      <option value="anuncio">📢 Anuncio</option>
+      <option value="evento">🎉 Evento</option>
+    </select>
+  );
+}

--- a/src/components/Sidebar/MiniCalendar.jsx
+++ b/src/components/Sidebar/MiniCalendar.jsx
@@ -1,0 +1,36 @@
+import React, { useContext } from "react";
+import { getWeekKey } from "../../utils/dateUtils";
+import CalendarContext from "../../hooks/useCalendar";
+
+export default function MiniCalendar({ month, year, days }) {
+  const { currentWeek, setCurrentWeek } = useContext(CalendarContext);
+
+  const di = new Date(year, month, 0).getDate();
+  const sd = new Date(year, month - 1, 1).getDay();
+  const bl = sd ? sd - 1 : 6;
+
+  return (
+    <div id="mini-calendar">
+      {["L","M","Mi","J","V","S","D"].map((h, i) => (
+        <div key={i} className="day-header">{h}</div>
+      ))}
+      {Array.from({ length: bl }).map((_, i) => (
+        <div key={`b${i}`} />
+      ))}
+      {Array.from({ length: di }, (_, i) => {
+        const dayNum = i + 1;
+        const wk = getWeekKey(year, month, dayNum);
+        const active = wk === currentWeek;
+        return (
+          <div
+            key={dayNum}
+            className={`day-cell ${active ? "active" : ""}`}
+            onClick={() => setCurrentWeek(wk)}
+          >
+            {dayNum}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Sidebar/MonthPopover.jsx
+++ b/src/components/Sidebar/MonthPopover.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+export default function MonthPopover({ showMonthPopover, setShowMonthPopover, setMonth, monthNames }) {
+  if (!showMonthPopover) return null;
+  return (
+    <div className="popover month-grid">
+      {monthNames.map((m, i) => (
+        <button
+          key={i}
+          onClick={() => {
+            setMonth(i + 1);
+            setShowMonthPopover(false);
+          }}
+        >
+          {m.slice(0, 3)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import MiniCalendar from "./MiniCalendar";
+import CategorySelector from "./CategorySelector";
+import { exportWeekPdf } from "../../utils/pdfUtils";
+
+export default function Sidebar({
+  month, setShowMonthPopover,
+  year, setShowYearPopover,
+  monthNames, days,
+  setDarkMode, darkMode,
+  currentWeek, tasksByDay,
+  setShowMultiForm
+}) {
+  return (
+    <aside className="sidebar">
+      <div className="calendar-nav">
+        <button onClick={() => setShowMonthPopover(true)} className="nav-btn">
+          {monthNames[month - 1]}
+        </button>
+        <button onClick={() => setShowYearPopover(true)} className="nav-btn">
+          {year}
+        </button>
+      </div>
+
+      <MiniCalendar month={month} year={year} days={days} />
+
+      <button id="toggleDarkMode" onClick={() => setDarkMode(!darkMode)}>
+        {darkMode ? "☀️ Modo claro" : "🌙 Modo noche"}
+      </button>
+
+      <h3>✏️ Acciones</h3>
+      <CategorySelector />
+
+      <button onClick={() => setShowMultiForm(true)}>➕ Crear en varios días</button>
+      <button onClick={() => exportWeekPdf(currentWeek, tasksByDay)}>📄 Exportar PDF</button>
+    </aside>
+  );
+}

--- a/src/components/Sidebar/YearPopover.jsx
+++ b/src/components/Sidebar/YearPopover.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+
+export default function YearPopover({ showYearPopover, setShowYearPopover, setYear, year }) {
+  const [inputYear, setInputYear] = useState(year);
+
+  if (!showYearPopover) return null;
+  return (
+    <div className="popover">
+      <input
+        type="number"
+        value={inputYear}
+        onChange={(e) => setInputYear(parseInt(e.target.value))}
+      />
+      <button
+        onClick={() => {
+          setYear(inputYear);
+          setShowYearPopover(false);
+        }}
+      >
+        Confirmar
+      </button>
+    </div>
+  );
+}

--- a/src/components/styles/darkMode.css
+++ b/src/components/styles/darkMode.css
@@ -1,0 +1,34 @@
+body.dark-mode {
+  background: #121212;
+  color: #eee;
+}
+
+body.dark-mode .sidebar,
+body.dark-mode .day-column {
+  background: #1e1e1e;
+}
+
+body.dark-mode .nav-btn {
+  color: #ccc;
+}
+
+body.dark-mode .nav-btn:hover {
+  background: #4e89ff;
+  color: white;
+}
+
+body.dark-mode .day-cell,
+body.dark-mode .day-checkbox {
+  background: #333;
+  color: #ccc;
+}
+
+body.dark-mode .day-cell:hover,
+body.dark-mode .day-checkbox.active {
+  background: #4e89ff;
+  color: white;
+}
+
+body.dark-mode .task-menu-btn {
+  color: white;
+}

--- a/src/components/styles/style.css
+++ b/src/components/styles/style.css
@@ -1,0 +1,225 @@
+/* Reset */
+html, body {
+  margin: 0;
+  height: 100%;
+  font-family: 'Nunito', sans-serif;
+  background: #f0f4f8;
+  color: #222;
+}
+
+.app-container {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* Sidebar */
+.sidebar {
+  width: 280px;
+  background: white;
+  padding: 20px;
+  box-shadow: 2px 0 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.calendar-nav {
+  display: flex;
+  gap: 8px;
+}
+
+.nav-btn {
+  font-size: 18px;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  padding: 6px 12px;
+  transition: 0.3s;
+}
+
+.nav-btn:hover {
+  background: rgba(78, 137, 255, 0.2);
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+
+#mini-calendar {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  font-size: 12px;
+  text-align: center;
+}
+
+#mini-calendar .day-header {
+  font-weight: bold;
+}
+
+.day-cell {
+  padding: 8px;
+  border-radius: 8px;
+  background: #e4ecff;
+  cursor: pointer;
+}
+
+.day-cell:hover, .day-cell.active {
+  background: #4e89ff;
+  color: white;
+  font-weight: bold;
+}
+
+button, select {
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-radius: 8px;
+  background: #4e89ff;
+  color: white;
+  font-size: 14px;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+button:hover, select:hover {
+  background: #376ee2;
+}
+
+main {
+  flex: 1;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Semana y calendario */
+.week-display {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+#calendar {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  height: 100%;
+}
+
+.day-column {
+  flex: 1;
+  background: white;
+  border-radius: 12px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  min-width: 160px;
+}
+
+.day-header {
+  text-align: center;
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
+.add-task-btn {
+  background: #4e89ff;
+  color: white;
+  font-size: 14px;
+  margin-top: auto;
+  width: 100%;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.task-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.task {
+  position: relative;
+  padding: 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  overflow-wrap: break-word;
+  min-height: 50px;
+}
+
+.task:hover {
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+}
+
+.task.selected {
+  border: 2px solid black;
+}
+
+/* Colores categorías */
+.task.tarea   { background: #ffe07d; }
+.task.trabajo { background: #ffb347; }
+.task.anuncio { background: #87cefa; }
+.task.evento  { background: #90ee90; }
+
+/* Popovers */
+.popover {
+  position: absolute;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  z-index: 100;
+}
+.hidden { display: none; }
+
+.month-grid {
+  display: grid;
+  grid-template-columns: repeat(3,1fr);
+  gap: 4px;
+}
+
+.month-grid button,
+#confirmYearBtn,
+#taskMenu button,
+#multiConfirm {
+  background: #4e89ff;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 6px;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+#yearInput, #multiTitle {
+  width: 100%;
+  padding: 6px;
+  margin-bottom: 8px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+#multiDays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.day-checkbox {
+  padding: 8px;
+  border-radius: 8px;
+  background: #e4ecff;
+  text-align: center;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.day-checkbox.active {
+  background: #4e89ff;
+  color: white;
+  font-weight: bold;
+}

--- a/src/components/utils/dateUtils.js
+++ b/src/components/utils/dateUtils.js
@@ -1,0 +1,12 @@
+export const days = ['Lunes','Martes','Miércoles','Jueves','Viernes','Sábado','Domingo'];
+
+export function getWeekKey(y, m, d) {
+  const dt = new Date(y, m - 1, d);
+  const w = Math.ceil((dt.getDate() + (dt.getDay() ? dt.getDay() - 1 : 6)) / 7);
+  return `${y}_${m}_${w}`;
+}
+
+export function monthNames() {
+  return ['Enero','Febrero','Marzo','Abril','Mayo','Junio',
+          'Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
+}

--- a/src/components/utils/pdfUtils.js
+++ b/src/components/utils/pdfUtils.js
@@ -1,0 +1,23 @@
+import { jsPDF } from "jspdf";
+import { days } from "./dateUtils";
+
+export function exportWeekPdf(weekKey, tasksByDay) {
+  const doc = new jsPDF();
+  doc.setFontSize(12);
+  doc.text(`Semana ${weekKey}`, 10, 10);
+  let y = 20;
+
+  days.forEach(d => {
+    doc.setFont(undefined, "bold");
+    doc.text(d, 10, y);
+    y += 6;
+    doc.setFont(undefined, "normal");
+    (tasksByDay[d] || []).forEach(task => {
+      doc.text(`- ${task.text}`, 12, y);
+      y += 6;
+    });
+    y += 4;
+  });
+
+  doc.save(`Semana_${weekKey}.pdf`);
+}

--- a/src/hooks/useCalendar.js
+++ b/src/hooks/useCalendar.js
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { getWeekKey } from "../utils/dateUtils";
+
+export default function useCalendar() {
+  const [month, setMonth] = useState(7);
+  const [year, setYear] = useState(2025);
+  const [currentWeek, setCurrentWeek] = useState(getWeekKey(2025, 7, 1));
+  const [tasksByDay, setTasksByDay] = useState({});
+  const [darkMode, setDarkMode] = useState(false);
+  const [selectedTask, setSelectedTask] = useState(null);
+  const [showMonthPopover, setShowMonthPopover] = useState(false);
+  const [showYearPopover, setShowYearPopover] = useState(false);
+  const [showTaskMenu, setShowTaskMenu] = useState(false);
+  const [showMultiForm, setShowMultiForm] = useState(false);
+
+  const addTask = (day, cat, text = "Nueva tarea") => {
+    setTasksByDay(prev => ({
+      ...prev,
+      [day]: [...(prev[day] || []), { category: cat, text }]
+    }));
+  };
+
+  const deleteTask = () => {
+    if (!selectedTask) return;
+    const { day, index } = selectedTask;
+    setTasksByDay(prev => ({
+      ...prev,
+      [day]: prev[day].filter((_, i) => i !== index)
+    }));
+    setSelectedTask(null);
+    setShowTaskMenu(false);
+  };
+
+  const duplicateTask = () => {
+    if (!selectedTask) return;
+    const { day, task } = selectedTask;
+    addTask(day, task.category, task.text);
+    setShowTaskMenu(false);
+  };
+
+  return {
+    month, setMonth,
+    year, setYear,
+    currentWeek, setCurrentWeek,
+    tasksByDay, addTask, deleteTask, duplicateTask,
+    darkMode, setDarkMode,
+    selectedTask, setSelectedTask,
+    showMonthPopover, setShowMonthPopover,
+    showYearPopover, setShowYearPopover,
+    showTaskMenu, setShowTaskMenu,
+    showMultiForm, setShowMultiForm
+  };
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "../App.js";
+
+// Importa estilos globales
+import "./styles/style.css";
+import "./styles/darkMode.css";
+
+// Crea el root y renderiza la App
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- fix typo in Popovers component name, renaming `MultiTaskFrom.jsx` to `MultiTaskForm.jsx`
- ensure the component continues to export `MultiTaskForm` as default

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Calendario/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68936546d578832c82bc2c604d5a1ddb