### PR TITLE
feat: close popover when clicking outside

### DIFF
--- a/Calendario/src/components/Popovers/PopoverWrapper.jsx
+++ b/Calendario/src/components/Popovers/PopoverWrapper.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export default function PopoverWrapper({ children, visible, onClose, className = "" }) {
+  if (!visible) return null;
+
+  return (
+    <div onClick={onClose}>
+      <div
+        className={`popover ${className}`}
+        onClick={(e) => e.stopPropagation()} // evita cerrar al hacer click dentro
+      >
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow closing popover by clicking outside
- ensure internal clicks don't propagate, preventing accidental close

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Calendario/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689365488e0c832c97cab88e443c6a86